### PR TITLE
Fix kubestronaut link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The FAQ can be found as a [PDF document](FAQ.pdf).
 
-If you need to update your [Kubestronaut](https://www.cncf.io/people/kubestronaaut/) profile, please follow the below instructions by submitting a PR for approval. After a PR is merged, the CNCF site will reflect the update within 10 min.
+If you need to update your [Kubestronaut](https://www.cncf.io/training/kubestronaut/) profile, please follow the below instructions by submitting a PR for approval. After a PR is merged, the CNCF site will reflect the update within 10 min.
 
 For more information go to [CNCF People](https://github.com/cncf/people/blob/main/README.md).
 


### PR DESCRIPTION
the old URL link directed to a 404 page. I have corrected it so that it now points to the proper link where the information is displayed correctly.

---
Old link(https://www.cncf.io/people/kubestronaaut/):
![image](https://github.com/ydFu/kubestronaut/assets/64598482/4ab5b114-ac53-4e8f-83f2-a690cd318afa)

---
New link(https://www.cncf.io/training/kubestronaut/)
![image](https://github.com/ydFu/kubestronaut/assets/64598482/6385615b-90f6-44bf-8799-43529041349d)

